### PR TITLE
minimalist flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "nixos-rsbuild"
 version = "0.1.0"
 authors = [ "Ben Pieters-Hawke <benphawke@gmail.com>" ]
 description = """
-`nixos-rsbuild` is a (slightly opinionated) rewrite of the `nixos-rebuild` cli utility.
+`nixos-rsbuild` is a (slightly opinionated) rewrite of the `nixos-rebuild` CLI-utility.
 
 The goals are as follows:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "nixos-rsbuild"
 version = "0.1.0"
-authors = ["Ben Pieters-Hawke <benphawke@gmail.com>"]
+authors = [ "Ben Pieters-Hawke <benphawke@gmail.com>" ]
 description = """
-`nixos-rsbuild` is a (slightly opinionated) rewrite of the `nixos-rebuild` cli utility. The goals are as follows
+`nixos-rsbuild` is a (slightly opinionated) rewrite of the `nixos-rebuild` cli utility.
+
+The goals are as follows:
 
  - minimal barrier-of-entry to read/write the codebase in a meaningful way
  - provide a pleasant documentation/help UX
@@ -12,8 +14,8 @@ description = """
  - (Stretch): Cover all supported use-cases of `nixos-rebuild`
 """
 edition = "2021"
-keywords = ["nixos", "nix"]
-catagories = ["command-line-utilitios"]
+keywords = [ "nixos", "nix" ]
+catagories = [ "command-line-utilities" ]
 license = "Unlicense OR MIT"
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1728888510,
@@ -36,44 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728959392,
-        "narHash": "sha256-fp4he1QQjE+vasDMspZYeXrwTm9otwEqLwEN6FKZ5v0=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "4c6e317300f05b8871f585b826b6f583e7dc4a9b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
         nixos-rsbuild = final.callPackage ./package.nix { };
       };
 
+      nixosModules.default = ./module.nix;
+
       formatter = forSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
     };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+{
+  options.programs.nixos-rsbuild.enable = lib.mkEnableOption "";
+
+  config = lib.mkIf config.programs.nixos-rsbuild.enable {
+    environment.systemPackages = [
+      (pkgs.callPackage ./package.nix { })
+    ];
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,22 @@
+{ lib
+, rustPlatform
+, rev ? null
+, project ? (lib.importTOML ./Cargo.toml).package
+}:
+
+rustPlatform.buildRustPackage {
+  pname = project.name;
+  version = project.version + lib.optionalString (rev!=null) rev;
+
+  src = ./.;
+
+  cargoLock.lockFile = ./Cargo.lock;
+
+  meta = {
+    description = "A slightly opinionated RIIR of the nixos-rebuild CLI-tool";
+    longDescription = project.description;
+    homepage = "https://github.com/Ben-PH/nixos-rsbuild";
+    license = lib.licenses.mit;
+    mainProgram = "nixos-rsbuild";
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,12 +1,13 @@
-{ lib
-, rustPlatform
-, rev ? null
-, project ? (lib.importTOML ./Cargo.toml).package
+{
+  lib,
+  rustPlatform,
+  rev ? null,
+  project ? (lib.importTOML ./Cargo.toml).package,
 }:
 
 rustPlatform.buildRustPackage {
   pname = project.name;
-  version = project.version + lib.optionalString (rev!=null) rev;
+  version = project.version + lib.optionalString (rev != null) rev;
 
   src = ./.;
 
@@ -16,6 +17,10 @@ rustPlatform.buildRustPackage {
     description = "A slightly opinionated RIIR of the nixos-rebuild CLI-tool";
     longDescription = project.description;
     homepage = "https://github.com/Ben-PH/nixos-rsbuild";
+    maintainers = with lib.maintainers; [
+      "benphawke@gmail.com"
+      confus
+    ];
     license = lib.licenses.mit;
     mainProgram = "nixos-rsbuild";
   };


### PR DESCRIPTION
This is just the bare minimum required flake for people to be useful.

First commit removes flake-utils and the oxalica rust overlay. Reasoning: [ayats](https://ayats.org/blog/no-flake-utils) plus oxalica is a rather heavy download (slowing things down for people) and makes some decisions about dev environment that should be up to them.

It also factors out the packaging logic into `package.nix` for use with `callPackage` so you can easily upstream the thing to nixpkgs, once you're happy.

It's intended as a conversation starter for what might be useful to add in, especially re: dev-shells, not the be-all and end-all or my actually preferred solution. 

Other possible things for the flake:
 - NixOS module, that just adds a `programs.nixos-rsbuild.enable` option
 - Nixpkgs overlay for convenience
 - Formatter for `nix flake fmt`
   ```nix
   outputs.formatter = forSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
   ```
 - Tests for `nix flake check`
   ```nix
   outputs.checks = ...;
   ```