### PR TITLE
Dispatch `switch-to-configuration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -176,6 +182,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cmd_lib"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "371c15a3c178d0117091bd84414545309ca979555b1aad573ef591ad58818d41"
+dependencies = [
+ "cmd_lib_macros",
+ "env_logger 0.10.2",
+ "faccess",
+ "lazy_static",
+ "log",
+ "os_pipe",
+]
+
+[[package]]
+name = "cmd_lib_macros"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb844bd05be34d91eb67101329aeba9d3337094c04fd8507d821db7ebb488eaf"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +227,19 @@ checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -221,16 +266,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hostname"
@@ -273,6 +341,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +371,12 @@ checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -323,7 +408,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -336,13 +421,16 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
- "env_logger",
+ "cmd_lib",
+ "env_logger 0.11.5",
  "hostname",
  "log",
  "nix",
  "semver",
  "serde",
  "serde_json",
+ "strum",
+ "tempdir",
  "tempfile",
 ]
 
@@ -362,6 +450,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +497,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -409,17 +566,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -481,6 +653,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +683,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -502,6 +706,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -570,6 +783,37 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ The goals are as follows:
 """
 edition = "2021"
 keywords = [ "nixos", "nix" ]
-catagories = [ "command-line-utilities" ]
+# catagories = [ "command-line-utilities" ]
 license = "Unlicense OR MIT"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ license = "Unlicense OR MIT"
 camino = "1.1.9"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.20", features = ["derive"] }
+cmd_lib = "1.9.5"
 env_logger = "0.11.5"
 hostname = "0.4.0"
 log = "0.4.22"
@@ -30,4 +31,6 @@ nix = { version = "0.29.0", features = ["user"] }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.132"
+strum = { version = "0.26.3", features = ["derive", "strum_macros"] }
+tempdir = "0.3.7"
 tempfile = "3.13.0"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 - `cargo run -- -h` show top level help
 - `cargo run -- --help` show top level help in long-form
-- `cargo run -- <subcommand> -h` show subcommand help
-- `cargo run -- <subcommand> --help` show subcommand help in long-form
+- `cargo run -- <builders | utils> -h` show information on the two classes of tasks
+- `cargo run -- <subcommand> <task> --help` show task help in long-form
  
 #### For the "Rust Curious/Skeptic"
 
@@ -35,11 +35,11 @@ NOTE: `<flakeref>` => `/path/to/dir#flake.attr`
 1. [x] `nixos-rsbuild list-generations [--json]`
 1. [x] `nixos-rsbuild build`
 1. [x] `nixos-rsbuild build --flake /path/to#machine_name`
-2. [ ] `nixos-rebuild boot --flake <flakeref>` -> `nixos-rs boot <flakeref>`
-3. [ ] `nixos-rebuild boot` -> `nixos-rsbuild boot --config`
-4. [ ] `nixos-rebuild test ...` -> `nixos-rsbuild test ...`
-5. [ ] `nixos-rebuild switch ...` -> `nixos-rsbuild switch ...`
-6. [ ] `nixos-rebuild switch | boot | test ... --use-remote-sudo` -> `nixos-rsbuild <switch | boot | test> -s ...`
+2. [x] `nixos-rebuild boot --flake <flakeref>` -> `nixos-rs boot <flakeref>`
+3. [x] `nixos-rebuild boot` -> `nixos-rsbuild boot --config`
+4. [x] `nixos-rebuild test ...` -> `nixos-rsbuild test ...`
+5. [x] `nixos-rebuild switch ...` -> `nixos-rsbuild switch ...`
+6. [x] `nixos-rebuild switch | boot | test ... --use-remote-sudo` -> `nixos-rsbuild <switch | boot | test> -s ...`
 
 #### TODOs
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -60,15 +60,15 @@ pub enum UtilSubCommand {
 // TODO: split build and non-build commands
 #[derive(Subcommand, Debug)]
 pub enum SubCommand {
-    Builder {
+    Builders {
         #[command(subcommand)]
-        comm: BuildSubComms,
+        task: BuildSubComms,
         #[clap(flatten)]
         arg: AllArgs,
     },
     Util {
         #[command(subcommand)]
-        comm: UtilSubCommand,
+        task: UtilSubCommand,
     },
 }
 
@@ -207,7 +207,7 @@ impl SubCommand {
     /// ...And that should be a flag to clean up the arg architecture, no?
     pub fn inner_args(&self) -> Option<&AllArgs> {
         match self {
-            SubCommand::Builder { arg, .. } => Some(arg),
+            SubCommand::Builders { arg, .. } => Some(arg),
             _ => None,
         }
     }

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -55,26 +55,17 @@ impl Display for FlakeRef {
 }
 
 impl FlakeRef {
-    pub fn build_cmd(&self, out_dir: Option<&Utf8Path>) -> io::Result<CliCommand> {
+    pub fn build_cmd(&self, out_dir: &Utf8Path) -> io::Result<CliCommand> {
         log::info!("Building in flake mode.");
 
-        if let Some(out_dir) = out_dir {
-            if !out_dir.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("requested out dir not a directory: {}", out_dir),
-                ));
-            }
-        }
-
-        let out_dir = out_dir.unwrap_or(Utf8Path::new(".")).join("result");
-        let mut cmd = CliCommand::new("nix");
+        let mut cmd = CliCommand::new("nom");
         cmd.args([
             "build",
             self.to_string().as_str(),
             "--out-link",
-            out_dir.as_str(),
+            out_dir.join("result").as_str(),
         ]);
+        log::info!("created cmd: {:?}", cmd);
         Ok(cmd)
     }
 }

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -4,7 +4,6 @@ use std::{
     ffi::OsStr,
     fmt::Display,
     io::{self, ErrorKind},
-    process::Command as CliCommand,
 };
 
 mod attribute;
@@ -201,35 +200,5 @@ mod tests {
         assert!(FlakeRefInput::try_from("/fizz/buzz#").is_err());
         assert!(FlakeRefInput::try_from("/fizz/buzz#foo#").is_err());
         assert!(FlakeRefInput::try_from(r#"/fizz/buzz#foo""#).is_err());
-    }
-
-    #[test]
-    fn flake_build_cmd() {
-        let data = FlakeRef {
-            source: FlakeDir {
-                canoned_dir: Utf8PathBuf::from("/fizz/buzz"),
-            },
-            output_selector: Some(FlakeAttr {
-                attr_path: vec!["fizz".into()],
-            }),
-        };
-
-        let cmd = data.run_nix_build(None).unwrap();
-        assert_eq!(
-            format!("{:?}", cmd),
-            r#""nix" "build" "/fizz/buzz#fizz" "--out-link" "./result""#
-        );
-        let tmp = tempfile::tempdir_in(".").unwrap();
-        let tmp = tmp.path();
-        let cmd = data
-            .run_nix_build(Some(Utf8Path::from_path(tmp).unwrap()))
-            .unwrap();
-        assert_eq!(
-            format!("{:?}", cmd),
-            format!(
-                r#""nix" "build" "/fizz/buzz#fizz" "--out-link" "{}/result""#,
-                tmp.display()
-            )
-        );
     }
 }

--- a/src/list_generations.rs
+++ b/src/list_generations.rs
@@ -9,7 +9,7 @@ use std::{
     process::Command,
 };
 
-use crate::cmd::SubCommand;
+use crate::cmd::{SubCommand, UtilSubCommand};
 
 const GEN_DIR: &str = "/nix/var/nix/profiles";
 
@@ -173,7 +173,12 @@ impl GenerationMeta {
     pub fn dispatch_cmd(
         cmd: &SubCommand,
     ) -> Option<io::Result<impl Iterator<Item = (GenNumber, Self)>>> {
-        if matches!(cmd, SubCommand::ListGenerations { .. }) {
+        if matches!(
+            cmd,
+            SubCommand::Util {
+                comm: UtilSubCommand::ListGenerations { .. }
+            }
+        ) {
             Some(Self::run_cmd())
         } else {
             None

--- a/src/list_generations.rs
+++ b/src/list_generations.rs
@@ -176,7 +176,7 @@ impl GenerationMeta {
         if matches!(
             cmd,
             SubCommand::Util {
-                comm: UtilSubCommand::ListGenerations { .. }
+                task: UtilSubCommand::ListGenerations { .. }
             }
         ) {
             Some(Self::run_cmd())
@@ -234,7 +234,7 @@ impl GenerationMeta {
 // General file utilities
 mod file_utils {
     use std::{
-        ffi::{OsStr, OsString},
+        ffi::OsStr,
         io,
         path::{Path, PathBuf},
     };
@@ -245,7 +245,8 @@ mod file_utils {
         Directory,
         ExtDrv,
         ExtMissing,
-        ExtOther(OsString),
+        // ExtOther(OsString),
+        ExtOther(()),
     }
     /// <https://nix.dev/manual/nix/2.24/protocols/store-path#store-path-proper>
     /// `/nix/store/<digest>-<name>`
@@ -255,7 +256,7 @@ mod file_utils {
         /// TODO: actually decode back to the 20 bytes...
         digest: String,
         name: String,
-        entry_type: StoreEntryType,
+        _entry_type: StoreEntryType,
     }
 
     impl TryFrom<&Path> for CanonedStorePath {
@@ -294,7 +295,7 @@ mod file_utils {
             } else {
                 match cannoned.extension().and_then(OsStr::to_str) {
                     Some("drv") => StoreEntryType::ExtDrv,
-                    Some(d) => StoreEntryType::ExtOther(d.into()),
+                    Some(_d) => StoreEntryType::ExtOther(()),
                     None => StoreEntryType::ExtMissing,
                 }
             };
@@ -304,7 +305,7 @@ mod file_utils {
             Ok(Self {
                 digest: digest.to_string(),
                 name,
-                entry_type,
+                _entry_type: entry_type,
             })
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,15 +48,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // plain flake build
-    if let SubCommand::Builder {
-        comm,
+    if let SubCommand::Builders {
+        task: comm,
         arg,
-        // all: AllArgs {
-        //     flake,
-        //     no_flake: false,
-        //     ..
-        // },
-        // ..
     } = cli
     {
         log::trace!("getting full flake");

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,18 @@ fn main() -> Result<(), Box<dyn Error>> {
             sudo bash -c "env -i LOCALE_ARCHIVE=$local_arch $out_link $task_str";
         )?;
 
+        if use_td {
+            let sys_td = std::env::temp_dir();
+            assert!(std::fs::exists(&sys_td).unwrap());
+            assert!(path.starts_with(sys_td));
+            assert!(
+                path.file_name().unwrap().starts_with("nixrsbuild-"),
+                "{}",
+                path.file_name().unwrap()
+            );
+            std::fs::remove_dir_all(path);
+        }
+
         return Ok(());
     }
 


### PR DESCRIPTION
Split builder and non-builder tasks. builder tasks run `nix build ...`, and the ones that then need `switch-to-configuration` run that as well.

todo: dispatch `switch-to-configuration-ng` instead